### PR TITLE
fix: sharp locked at 0.32.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "chalk": "^5.3.0",
     "commander": "^11.0.0",
     "pixelmatch": "^5.3.0",
-    "sharp": "^0.32.4"
+    "sharp": "0.32.4"
   },
   "devDependencies": {
     "eslint": "*",


### PR DESCRIPTION
due to unavailability of upstream precompiled binaries for 0.32.5 on M1.